### PR TITLE
memory management, release tracking

### DIFF
--- a/argovis/Chart.yaml
+++ b/argovis/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.0"
+appVersion: "0.5.0"

--- a/argovis/templates/api-deployment.yaml
+++ b/argovis/templates/api-deployment.yaml
@@ -18,19 +18,15 @@ spec:
       containers:
         - name: argoapi
           image: "{{ .Values.api.repository }}:{{ .Values.api.tag }}"
+          imagePullPolicy: Always
+          env:
+          - name: NODE_OPTIONS
+            value: --max_old_space_size=2048
           resources:
             requests:
               memory: "0Gi"
               cpu: "0m"
             limits:
-              memory: "4Gi"
-              cpu: "1000m"
-          livenessProbe:
-            httpGet:
-              path: /profiles/overview
-              port: 8080
-              httpHeaders:
-              - name: x-argokey
-                value: xxx
-            initialDelaySeconds: 5
-            periodSeconds: 5
+              memory: {{ .Values.api.memory }}
+              cpu: {{ .Values.api.cpu }}
+

--- a/argovis/templates/datapages-deployment.yaml
+++ b/argovis/templates/datapages-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: datapages
 spec:
-  replicas: 1
+  replicas: {{ .Values.datapages.replicas }}
   selector:
     matchLabels:
       app: datapages
@@ -30,5 +30,5 @@ spec:
               memory: "0Gi"
               cpu: "0m"
             limits:
-              memory: "500Mi"
-              cpu: "250m"
+              memory: {{ .Values.datapages.memory }}
+              cpu: {{ .Values.datapages.cpu }}

--- a/argovis/templates/mongo-deployment.yaml
+++ b/argovis/templates/mongo-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: mongo
 spec:
-  replicas: 1
+  replicas: {{ .Values.mongo.replicas }}
   selector:
     matchLabels:
       app: mongo
@@ -27,8 +27,8 @@ spec:
               memory: "0Gi"
               cpu: "0m"
             limits:
-              memory: "8Gi"
-              cpu: "1000m"
+              memory: {{ .Values.mongo.memory }}
+              cpu: {{ .Values.mongo.cpu }}
           volumeMounts:
             - mountPath: "/data/db"
               name: mongostore
@@ -39,6 +39,6 @@ spec:
               - --eval
               - db.adminCommand('ping')
             failureThreshold: 3
-            periodSeconds: 10
+            periodSeconds: 300
             successThreshold: 1
             timeoutSeconds: 5

--- a/argovis/templates/ng-deployment.yaml
+++ b/argovis/templates/ng-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: ng
 spec:
-  replicas: 1
+  replicas: {{ .Values.ng.replicas }}
   selector:
     matchLabels:
       app: ng
@@ -34,8 +34,8 @@ spec:
               memory: "0Gi"
               cpu: "0m"
             limits:
-              memory: "1Gi"
-              cpu: "250m"
+              memory: {{ .Values.ng.memory }}
+              cpu: {{ .Values.ng.cpu }}
       securityContext:
         runAsUser: 1000830000
         runAsGroup: 1000830000

--- a/argovis/templates/redis-deployment.yaml
+++ b/argovis/templates/redis-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: redis
 spec:
-  replicas: 1
+  replicas: {{ .Values.redis.replicas }}
   selector:
     matchLabels:
       app: redis
@@ -23,8 +23,8 @@ spec:
               memory: "0Mi"
               cpu: "0m"
             limits:
-              memory: "500Mi"
-              cpu: "250m"
+              memory: {{ .Values.redis.memory }}
+              cpu: {{ .Values.redis.cpu }}
           livenessProbe:
             exec:
               command:

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -1,18 +1,32 @@
 mongo:
   repository: mongo
   tag: 4.2.3
+  replicas: 1
+  memory: "8Gi"
+  cpu: "2000m"
 redis:
   repository: argovis/redis
   tag: 6.2.6-211114
+  replicas: 1
+  memory: "500Mi"
+  cpu: "100m"
 api:
   repository: argovis/api
-  tag: 2.0.0-rc1
-  replicas: 1
+  tag: 2.0.0-rc2
+  replicas: 2
+  memory: "2Gi"
+  cpu: "250m"
 ng:
   repository: argovis/ng
   tag: 2.0.0-rc4
+  replicas: 1
   api_root: http://argovis-api-atoc-argovis-dev.apps.containers01.colorado.edu
   dp_root: http://argovis-datapages-atoc-argovis-dev.apps.containers01.colorado.edu
+  memory: "1Gi"
+  cpu: "250m"
 datapages:
   repository: argovis/datapages
   tag: 2.0.0-rc2
+  replicas: 1
+  memory: "500Mi"
+  cpu: "250m"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   ng:
-    image: argovis/ng:2.0.0-rc2
+    image: argovis/ng:2.0.0-rc5
     user: 1000830000:1000830000
     restart: always
     environment:
@@ -18,7 +18,7 @@ services:
     volumes:
        - /storage/mongodb:/data/db:Z
   api:
-    image: argovis/api:2.0.0-rc1
+    image: argovis/api:2.0.0-rc2
     restart: always
     ports:
      - 8080:8080


### PR DESCRIPTION
 - Node has its own internal memory management which needed to be raised to match the kube limit
 - General refactors
 - Tracking https://github.com/argovis/argovisNg/pull/8 and https://github.com/argovis/argovis_api/pull/44