### PR TITLE
rename storage backing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Argovis consists of five microservices, wihch all have their own release process
 
 Also, this chart assumes there exists the following objects in the cluster: 
 
- - a PVC called `mongoback`, which contains everything from `/data/db` in the mongo container.
+ - a PVC called `mongoback0`, which contains everything from `/data/db` in the mongo container.
  - a secret called `apitoken`, which contains a key `token` that will be used as an API token. This token must be present and active in mongodb.
 
 When any of the underlying base images change, or anything about the orchestration structure changes, follow the procedures below to increment the release on the OKD cluster:

--- a/argovis/templates/mongo-deployment.yaml
+++ b/argovis/templates/mongo-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       volumes:
         - name: mongostore
           persistentVolumeClaim:
-            claimName: mongoback
+            claimName: mongoback0
       containers:
         - name: task-pv-container
           image: "{{ .Values.mongo.repository }}:{{ .Values.mongo.tag }}"


### PR DESCRIPTION
in anticipation of needing more than one of them, when we move to a replicaset or sharded db.