### PR TITLE
bounce API and keymanager if mongo connection fails

### DIFF
--- a/argovis/templates/api-deployment.yaml
+++ b/argovis/templates/api-deployment.yaml
@@ -28,6 +28,13 @@ spec:
             limits:
               memory: {{ .Values.api.memory }}
               cpu: {{ .Values.api.cpu }}
+          startupProbe:
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 5
+            httpGet:
+              path: /profiles/overview
+              port: 8080
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -32,7 +32,7 @@ datapages:
   cpu: "250m"
 keymanager:
   repository: argovis/apikey-manager
-  tag: 2.0.0-rc1
+  tag: 2.0.0-rc2
   replicas: 1
   memory: "100Mi"
   cpu: "100m"


### PR DESCRIPTION
API uses a startupProbe and an httpGet check since it can infer from its own endpoints whether it connected or not; keymanager just reboots itself and relies on Kube to restart it.