### PR TITLE
TLS encryption; missing yaml

### DIFF
--- a/argovis/Chart.yaml
+++ b/argovis/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.15.0"

--- a/argovis/templates/inbound-api-route.yaml
+++ b/argovis/templates/inbound-api-route.yaml
@@ -12,6 +12,10 @@ spec:
     weight: 100
   port:
     targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None
 status:
   ingress:
     - host: argovis-api-atoc-argovis-dev.apps.containers02.colorado.edu

--- a/argovis/templates/inbound-datapages-route.yaml
+++ b/argovis/templates/inbound-datapages-route.yaml
@@ -10,6 +10,10 @@ spec:
     weight: 100
   port:
     targetPort: 3000
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None
 status:
   ingress:
     - host: argovis-datapages-atoc-argovis-dev.apps.containers02.colorado.edu

--- a/argovis/templates/inbound-frontend-route.yaml
+++ b/argovis/templates/inbound-frontend-route.yaml
@@ -10,6 +10,10 @@ spec:
     weight: 100
   port:
     targetPort: 3000
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None
 status:
   ingress:
     - host: argovis-atoc-argovis-dev.apps.containers02.colorado.edu

--- a/argovis/templates/inbound-keymanager-route.yaml
+++ b/argovis/templates/inbound-keymanager-route.yaml
@@ -1,0 +1,24 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: apikey-manager
+  annotations:
+    haproxy.router.openshift.io/timeout: 5m
+spec:
+  host: argovis-apikey-manager-atoc-argovis-dev.apps.containers02.colorado.edu
+  to:
+    kind: Service
+    name: apikey-manager
+    weight: 100
+  port:
+    targetPort: 3030
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None
+status:
+  ingress:
+    - host: argovis-apikey-manager-atoc-argovis-dev.apps.containers02.colorado.edu
+      routerName: default
+      routerCanonicalHostname: apps.containers02.colorado.edu
+

--- a/argovis/templates/keymanager-deployment.yaml
+++ b/argovis/templates/keymanager-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keymanager-deployment
+spec:
+  replicas: {{ .Values.keymanager.replicas }}
+  selector:
+    matchLabels:
+      component: keymanager
+  template:
+    metadata:
+      name: apikeymanager
+      labels:
+        component: keymanager
+        tier: api
+    spec:
+      containers:
+        - name: keymanager
+          image: "{{ .Values.keymanager.repository }}:{{ .Values.keymanager.tag }}"
+          imagePullPolicy: Always
+          env:
+          - name: SENDGRID_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: sendgrid-api-token
+                key: SENDGRID_API_KEY
+          resources:
+            requests:
+              memory: "0Gi"
+              cpu: "0m"
+            limits:
+              memory: {{ .Values.keymanager.memory }}
+              cpu: {{ .Values.keymanager.cpu }}
+
+
+
+

--- a/argovis/templates/keymanager-nodeport.yaml
+++ b/argovis/templates/keymanager-nodeport.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: apikey-manager
+spec:
+  type: NodePort
+  selector:
+    component: keymanager
+  ports:
+    - port: 3030
+      targetPort: 3030

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -20,8 +20,8 @@ ng:
   repository: argovis/ng
   tag: 2.0.0-rc6
   replicas: 1
-  api_root: http://argovis-api-atoc-argovis-dev.apps.containers02.colorado.edu
-  dp_root: http://argovis-datapages-atoc-argovis-dev.apps.containers02.colorado.edu
+  api_root: https://argovis-api-atoc-argovis-dev.apps.containers02.colorado.edu
+  dp_root: https://argovis-datapages-atoc-argovis-dev.apps.containers02.colorado.edu
   memory: "1Gi"
   cpu: "250m"
 datapages:


### PR DESCRIPTION
 - TLS encrypt all the things using CU's certs at router edge
 - remember to include all the manifests for the keymanager, should have been included in #19 