### PR TITLE
prepping 0.22.0

### DIFF
--- a/argovis/Chart.yaml
+++ b/argovis/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.21.0"
+appVersion: "0.22.0"

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -1,19 +1,19 @@
 mongo:
   repository: mongo
-  tag: 5.0.6
+  tag: 5.0.9
   replicas: 1
   memory: "8Gi"
   cpu: "500m"
   pvcbacking: "atoc-argovis-dev-nfs-pvc"
 redis:
   repository: argovis/redis
-  tag: 6.2.6-220415
+  tag: 7.0.2-220619
   replicas: 1
   memory: "250Mi"
   cpu: "100m"
 api:
   repository: argovis/api
-  tag: 2.0.0-rc17
+  tag: 2.0.0-rc21
   replicas: 2
   memory: "1500Mi"
   cpu: "500m"
@@ -39,7 +39,7 @@ datapages:
   cpu: "250m"
 keymanager:
   repository: argovis/apikey-manager
-  tag: 2.0.0-rc4
+  tag: 2.0.0-rc6
   replicas: 1
   memory: "100Mi"
   cpu: "100m"


### PR DESCRIPTION
Tracking:

 - mongo 5.0.6 -> 5.0.9
 - https://github.com/argovis/argovis_redis/releases/tag/7.0.2-220619
 - https://github.com/argovis/argovis_api/releases/tag/2.0.0-rc21
 - https://github.com/argovis/apikey-manager/releases/tag/2.0.0-rc6