### PR TITLE
prometheus ttl

### DIFF
--- a/argovis/templates/prom-deployment.yaml
+++ b/argovis/templates/prom-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         - name: prom-server
           image: "{{ .Values.prom.repository }}:{{ .Values.prom.tag }}"
           imagePullPolicy: Always
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/data/prometheus"
+            - "--storage.tsdb.retention.time=90d"
           resources:
             requests:
               memory: "0Gi"

--- a/argovis/templates/prom-deployment.yaml
+++ b/argovis/templates/prom-deployment.yaml
@@ -23,6 +23,9 @@ spec:
           image: "{{ .Values.prom.repository }}:{{ .Values.prom.tag }}"
           imagePullPolicy: Always
           resources:
+            requests:
+              memory: "0Gi"
+              cpu: "0m"
             limits:
               memory: {{ .Values.prom.memory }}
               cpu: {{ .Values.prom.cpu }}

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -15,7 +15,7 @@ redis:
   cpu: "50m"
 api:
   repository: argovis/api
-  tag: 2.29.2
+  tag: 2.29.3
   replicas: 2
   memory: "1000Mi"
   cpu: "500m"

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -15,7 +15,7 @@ redis:
   cpu: "50m"
 api:
   repository: argovis/api
-  tag: 2.33.0
+  tag: dev
   replicas: 2
   memory: "2000Mi"
   cpu: "500m"
@@ -23,7 +23,7 @@ api:
   argonode: 'core'
 apix:
   repository: argovis/api
-  tag: 2.30.0
+  tag: dev
   replicas: 0
   memory: "2000Mi"
   cpu: "500m"
@@ -37,7 +37,7 @@ keymanager:
   cpu: "100m"
 frontend:
   repository: argovis/react
-  tag: 2.14.0
+  tag: 2.18.0
   replicas: 1
   memory: "1000Mi"
   cpu: "1000m"

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -15,7 +15,7 @@ redis:
   cpu: "50m"
 api:
   repository: argovis/api
-  tag: 2.31.1
+  tag: 2.33.0
   replicas: 2
   memory: "2000Mi"
   cpu: "500m"
@@ -23,7 +23,7 @@ api:
   argonode: 'core'
 apix:
   repository: argovis/api
-  tag: dev
+  tag: 2.30.0
   replicas: 0
   memory: "2000Mi"
   cpu: "500m"
@@ -37,7 +37,7 @@ keymanager:
   cpu: "100m"
 frontend:
   repository: argovis/react
-  tag: dev
+  tag: 2.14.0
   replicas: 1
   memory: "1000Mi"
   cpu: "1000m"

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -15,7 +15,7 @@ redis:
   cpu: "50m"
 api:
   repository: argovis/api
-  tag: dev
+  tag: 2.36.2
   replicas: 2
   memory: "2000Mi"
   cpu: "500m"
@@ -37,7 +37,7 @@ keymanager:
   cpu: "100m"
 frontend:
   repository: argovis/react
-  tag: 2.18.0
+  tag: dev
   replicas: 1
   memory: "1000Mi"
   cpu: "1000m"
@@ -45,6 +45,6 @@ prom:
   repository: argovis/prometheus
   tag: 240918-core
   replicas: 1
-  memory: "100Mi"
+  memory: "1000Mi"
   cpu: "100m"
   pvcbacking: prometheus-tsdb

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -15,9 +15,9 @@ redis:
   cpu: "50m"
 api:
   repository: argovis/api
-  tag: 2.30.0
+  tag: 2.31.1
   replicas: 2
-  memory: "1000Mi"
+  memory: "2000Mi"
   cpu: "500m"
   argocore: 'here'
   argonode: 'core'
@@ -25,7 +25,7 @@ apix:
   repository: argovis/api
   tag: dev
   replicas: 0
-  memory: "1000Mi"
+  memory: "2000Mi"
   cpu: "500m"
   argocore: 'here'
   argonode: 'core'

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -15,7 +15,7 @@ redis:
   cpu: "50m"
 api:
   repository: argovis/api
-  tag: 2.29.1
+  tag: 2.29.2
   replicas: 2
   memory: "1000Mi"
   cpu: "500m"

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -15,7 +15,7 @@ redis:
   cpu: "50m"
 api:
   repository: argovis/api
-  tag: 2.29.3
+  tag: 2.30.0
   replicas: 2
   memory: "1000Mi"
   cpu: "500m"

--- a/argovis/values.yaml
+++ b/argovis/values.yaml
@@ -43,7 +43,7 @@ frontend:
   cpu: "1000m"
 prom:
   repository: argovis/prometheus
-  tag: 240917
+  tag: 240918-core
   replicas: 1
   memory: "100Mi"
   cpu: "100m"


### PR DESCRIPTION
constrains prom data ttl to 90 days for a currently 50 GB storage backing - hopefully this is sized correctly now, will have to monitor over the next... 90 days.